### PR TITLE
Tests

### DIFF
--- a/src/pages/api/contact/list.js
+++ b/src/pages/api/contact/list.js
@@ -25,9 +25,7 @@ const handler = async (req, res) => {
   const validUserToGetData = ["me@ehsangazar.com", "exampleForTest@gmail.com"];
 
   if (!validUserToGetData.includes(req.user.email)) {
-    return res
-      .status(200)
-      .json({ status: false, message: "User not access to this page!" });
+    return res.status(200).json({ status: false, message: "Access denied!" });
   }
   const contacts = await prisma.contact.findMany();
 

--- a/tests/integrations/category/list.test.js
+++ b/tests/integrations/category/list.test.js
@@ -4,6 +4,14 @@ const endpoint = "/api/category/list";
 const url = baseUrl + endpoint;
 
 describe(endpoint, () => {
+  it("Should respond with code 405 if method is not GET", async () => {
+    try {
+      await axios.post(url);
+    } catch (err) {
+      expect(err.response.status).toBe(405);
+    }
+  });
+
   it("Should send the categories list", async () => {
     const res = await (await axios.get(url)).data;
     const categories = await res.data;

--- a/tests/integrations/contacts/list.test.js
+++ b/tests/integrations/contacts/list.test.js
@@ -1,0 +1,34 @@
+const { default: axios } = require("axios");
+const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://mockland.dev";
+const endpoint = "/api/contact/list";
+const url = baseUrl + endpoint;
+const invalidAuth = process.env.INVALID_TOKEN;
+
+describe(endpoint, () => {
+  it("Should respond with code 405 if method is not GET", async () => {
+    try {
+      await axios.post(url);
+    } catch (err) {
+      expect(err.response.status).toBe(405);
+    }
+  });
+
+  it("Should respond with code 400 if the auth header is not provided", async () => {
+    try {
+      await axios.get(url);
+    } catch (error) {
+      console.log(error);
+      expect(error.response.status).toBe(400);
+      expect(error.response.data.message).toBe("auth header is required");
+    }
+  });
+  xit("Should respond with code 400 if the auth header is not valid or doesn't exist", async () => {
+    try {
+      await axios.get(url, { headers: { auth: invalidAuth } });
+    } catch (error) {
+      console.log(error);
+      expect(error.response.status).toBe(400);
+      expect(error.response.data.message).toBe("Invalid auth token");
+    }
+  });
+});

--- a/tests/integrations/news/create.test.js
+++ b/tests/integrations/news/create.test.js
@@ -2,9 +2,9 @@ const { default: axios } = require("axios");
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://mockland.dev";
 const endpoint = "/api/news/create";
 const url = baseUrl + endpoint;
-const token = process.env.MEMBER_TEST_TOKEN;
+const token = process.env.INVALID_TOKEN;
 
-describe(endpoint + "/list", () => {
+describe(endpoint, () => {
   it("Should respond with code 405 if method is not POST", async () => {
     try {
       await axios.get(url, {
@@ -20,9 +20,25 @@ describe(endpoint + "/list", () => {
     }
   });
 
-  xit("Should respond with code 405 if method is not POST", async () => {
+  it("Should respond with code 400 if the token is not provided", async () => {
     try {
-      await axios.post(
+      await axios.post(url, {
+        title: "test",
+        description: "test",
+        content: "test",
+        image: "test",
+        slug: "test",
+        author: "test",
+      });
+    } catch (err) {
+      expect(err.response.status).toBe(400);
+      expect(err.response.data.message).toBe("token header is required");
+    }
+  });
+
+  xit("Should respond with code 400 if the token is invalid or doesn't exist", async () => {
+    try {
+      const res = await axios.post(
         url,
         {
           title: "test",
@@ -32,10 +48,16 @@ describe(endpoint + "/list", () => {
           slug: "test",
           author: "test",
         },
-        { headers: { token } }
+        {
+          headers: {
+            token,
+          },
+        }
       );
+      console.log(res);
+      expect(res.status).toBe(400);
     } catch (err) {
-      expect(err.response.status).toBe(422);
+      console.log(err);
     }
   });
 });

--- a/tests/integrations/news/create.test.js
+++ b/tests/integrations/news/create.test.js
@@ -2,17 +2,40 @@ const { default: axios } = require("axios");
 const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "https://mockland.dev";
 const endpoint = "/api/news/create";
 const url = baseUrl + endpoint;
+const token = process.env.MEMBER_TEST_TOKEN;
 
 describe(endpoint + "/list", () => {
-  xit("Should respond with code 422 if validation fails", async () => {
-    const res = await axios.post(url, {
-      title: "test",
-      description: "test",
-      content: "test",
-      image: "test",
-      slug: "test",
-      author: "test",
-    });
-    expect(res.status).toBe(422);
+  it("Should respond with code 405 if method is not POST", async () => {
+    try {
+      await axios.get(url, {
+        title: "test",
+        description: "test",
+        content: "test",
+        image: "test",
+        slug: "test",
+        author: "test",
+      });
+    } catch (err) {
+      expect(err.response.status).toBe(405);
+    }
+  });
+
+  xit("Should respond with code 405 if method is not POST", async () => {
+    try {
+      await axios.post(
+        url,
+        {
+          title: "test",
+          description: "test",
+          content: "test",
+          image: "test",
+          slug: "test",
+          author: "test",
+        },
+        { headers: { token } }
+      );
+    } catch (err) {
+      expect(err.response.status).toBe(422);
+    }
   });
 });

--- a/tests/integrations/news/list.test.js
+++ b/tests/integrations/news/list.test.js
@@ -5,6 +5,14 @@ const url = baseUrl + endpoint;
 
 describe(endpoint, () => {
   describe(endpoint, () => {
+    it("Should respond with code 405 if method is not GET", async () => {
+      try {
+        await axios.post(url);
+      } catch (err) {
+        expect(err.response.status).toBe(405);
+      }
+    });
+
     it("Should send 10 news. (Default page is 1 and limit is 10)", async () => {
       const res = await (await axios.get(url)).data;
       const news = await res.data;


### PR DESCRIPTION
In integration tests. In create.test.js files. Whenever I'm sending request via POST method and attach auth or token to the header of the request, this error occurs => Error: Response for preflight has invalid http status code 405. I checked the methods I used and there was no problem. I don't know where the error is coming from. In the past it used to be ok